### PR TITLE
404 fix and index styling

### DIFF
--- a/themes/hugo_theme_robust/layouts/index.html
+++ b/themes/hugo_theme_robust/layouts/index.html
@@ -5,6 +5,9 @@
 <div class="container">
   <div class="row">
     <div class="col-md-9">
+      <article class="single">
+        
+      <div class="body" id="customBody">
 
       <h1 class="p-page-title">R Training Curriculum</h1>
       
@@ -31,7 +34,10 @@
 
       {{ partial "pagination.html" . }}
 
+    </div><!--body-->
+    </article>
     </div>
+    
 
     <div class="col-md-3">
       {{ partial "sidebar.html" . }}

--- a/themes/hugo_theme_robust/layouts/partials/header_after.html
+++ b/themes/hugo_theme_robust/layouts/partials/header_after.html
@@ -48,7 +48,7 @@
 			
   <div class="p-logo">
     <div id="desktopNav">
-      <img id="mobileBurger" src="{{ $.Site.BaseURL }}/images/mobileburger.png" alt="mobile nav menu"/>
+      <img id="mobileBurger" src="{{ $.Site.BaseURL }}images/mobileburger.png" alt="mobile nav menu"/>
       <ul id="navigation">
         <li><a href="http://owi.usgs.gov/R/index.html">Home</a></li>
         <li><a href="http://owi.usgs.gov/R/about.html">About</a></li>

--- a/themes/hugo_theme_robust/static/css/styles.css
+++ b/themes/hugo_theme_robust/static/css/styles.css
@@ -7,6 +7,10 @@
 	 background: #e8e6e1 !important;
 	 font-family:"Open Sans", Gotham, "Helvetica Neue", Helvetica, Arial, sans-serif !important;
 	 }
+	 
+#customBody{
+  padding-top:10px;
+}
  
  aside.site header{
    color:#003366;
@@ -452,13 +456,13 @@ h5 { font-size: 1rem; line-height: 1rem; }
 
 .accordionSignal{
   float:right;
-  background:url('../../images/plus.png') no-repeat;
+  background:url('../images/plus.png') no-repeat;
   width:20px;
   height:20px;
 }
 
 .minus{
-  background:url('../../images/minus.png') no-repeat;
+  background:url('../images/minus.png') no-repeat;
   width:20px;
   height:20px;
 }


### PR DESCRIPTION
1. Hopefully have the correct file path for the images for dev to see. My local version always wants one extra ../ in it for me to see the images than dev does.

2. Used the themes classes on the index page to style it like the rest of the pages.

3. Changed the path for the mobile navigation icon.

@lindsaycarr This should fix the issues of seeing everything correctly