### PR TITLE
fake dates for additional resource pages

### DIFF
--- a/content/intro-curriculum/Additional_topics.Rmd
+++ b/content/intro-curriculum/Additional_topics.Rmd
@@ -1,4 +1,5 @@
 ---
+date: "9998-01-01"
 title: "Additional Topics in R"
 author: "Lindsay R. Carr"
 slug: "Additional"

--- a/content/intro-curriculum/Additional_topics.md
+++ b/content/intro-curriculum/Additional_topics.md
@@ -1,6 +1,6 @@
 ---
 author: Lindsay R. Carr
-date: 
+date: 9998-01-01
 slug: Additional
 title: Additional Topics in R
 image: 

--- a/content/intro-curriculum/Before-The-Workshop.Rmd
+++ b/content/intro-curriculum/Before-The-Workshop.Rmd
@@ -1,4 +1,5 @@
 ---
+date: "9998-01-01"
 title: "Before The Workshop"
 author: "Jeffrey W. Hollister & Luke Winslow"
 slug: "Before"

--- a/content/intro-curriculum/Before-The-Workshop.md
+++ b/content/intro-curriculum/Before-The-Workshop.md
@@ -1,6 +1,6 @@
 ---
 author: Jeffrey W. Hollister & Luke Winslow
-date: 
+date: 9998-01-01
 slug: Before
 title: Before The Workshop
 image: 

--- a/content/intro-curriculum/Crib_sheet.Rmd
+++ b/content/intro-curriculum/Crib_sheet.Rmd
@@ -1,4 +1,5 @@
 ---
+date: "9998-01-01"
 title: "Crib Sheet"
 author: "Lindsay R. Carr"
 slug: "Crib"

--- a/content/intro-curriculum/Crib_sheet.md
+++ b/content/intro-curriculum/Crib_sheet.md
@@ -1,6 +1,6 @@
 ---
 author: Lindsay R. Carr
-date: 
+date: 9998-01-01
 slug: Crib
 title: Crib Sheet
 image: 

--- a/content/intro-curriculum/Example_Schedule.Rmd
+++ b/content/intro-curriculum/Example_Schedule.Rmd
@@ -1,4 +1,5 @@
 ---
+date: "9998-01-01"
 title: "Example Schedule"
 author: "Lindsay R. Carr"
 slug: "Schedule"

--- a/content/intro-curriculum/Example_Schedule.md
+++ b/content/intro-curriculum/Example_Schedule.md
@@ -1,6 +1,6 @@
 ---
 author: Lindsay R. Carr
-date: 
+date: 9998-01-01
 slug: Schedule
 title: Example Schedule
 image: 

--- a/content/intro-curriculum/USGS-R_packages.Rmd
+++ b/content/intro-curriculum/USGS-R_packages.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "USGS-R Packages"
+date: "9998-01-01"
 author: "Lindsay R. Carr"
 slug: "USGS"
 output: USGSmarkdowntemplates::hugoTraining

--- a/content/intro-curriculum/USGS-R_packages.md
+++ b/content/intro-curriculum/USGS-R_packages.md
@@ -1,8 +1,8 @@
 ---
 author: Lindsay R. Carr
-date: 
+date: 9998-01-01
 slug: USGS
-title: USGS-R Packages
+title: 
 image: 
 menu:
   main:

--- a/content/intro-curriculum/data.Rmd
+++ b/content/intro-curriculum/data.Rmd
@@ -1,4 +1,5 @@
 ---
+date: "9998-01-01"
 title: "Data"
 slug: "data"
 output: USGSmarkdowntemplates::hugoTraining

--- a/content/intro-curriculum/data.md
+++ b/content/intro-curriculum/data.md
@@ -1,6 +1,6 @@
 ---
 author: 
-date: 
+date: 9998-01-01
 slug: data
 title: Data
 image: 


### PR DESCRIPTION
Jenkins dev build failed because I didn't have dates for the additional resource pages -- added fake ones so they would be in the correct order (these don't actually appear on the page, just used for ordering)