### PR TITLE
draft: True missing + shorten to CDI

### DIFF
--- a/content/course-specific-material/introR-CDI-May17.Rmd
+++ b/content/course-specific-material/introR-CDI-May17.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Community for Data Integration Conference"
+title: "2017 CDI Conference"
 date: "2017-05-19"
 slug: "introR-CDI-May17"
 output: USGSmarkdowntemplates::hugoTraining_course

--- a/content/course-specific-material/introR-CDI-May17.md
+++ b/content/course-specific-material/introR-CDI-May17.md
@@ -1,7 +1,7 @@
 ---
 date: 2017-05-19
 slug: introR-CDI-May17
-title: Community for Data Integration Conference
+title: 2017 CDI Conference
 menu:
   main:
     parent: Course Specific Material

--- a/content/r-package-dev/Defensive_Programming.md
+++ b/content/r-package-dev/Defensive_Programming.md
@@ -3,6 +3,7 @@ author: Alison P. Appling
 date: 9999-09-30
 slug: defense
 title: Defensive Programming
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/Package_Thoughts.md
+++ b/content/r-package-dev/Package_Thoughts.md
@@ -3,6 +3,7 @@ author:
 date: 9999-11-30
 slug: packages
 title: What Is a Package?
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/Writing_Tests.md
+++ b/content/r-package-dev/Writing_Tests.md
@@ -3,6 +3,7 @@ author: Jordan I. Walker
 date: 9999-08-31
 slug: writing-tests
 title: Writing Tests
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
@@ -103,10 +104,10 @@ Through a bit of magic we can look at the results of these tests. Normally this 
     ## 1 <NA> Valid pH values   pH values inside valid range return true  1
     ## 2 <NA> Valid pH values pH values outside valid range return false  2
     ## 3 <NA> Valid pH values                  pH edge cases return true  2
-    ##   failed skipped error warning  user system  real
-    ## 1      0   FALSE FALSE       0 0.001      0 0.001
-    ## 2      0   FALSE FALSE       0 0.001      0 0.001
-    ## 3      0   FALSE FALSE       0 0.001      0 0.001
+    ##   failed skipped error warning user system real
+    ## 1      0   FALSE FALSE       0    0      0    0
+    ## 2      0   FALSE FALSE       0    0      0    0
+    ## 3      0   FALSE FALSE       0    0      0    0
 
 One final set of tools in the testing toolbox are mocks. Mocks are used to isolate code so it isn't effected by other pieces that it depends on. As an example, really long running code is not good to have in tests since it is best to run tests often. So we will create a function that calls another function that takes a long time to return, but then mock that function in order to isolate the behavior.
 
@@ -130,7 +131,7 @@ One final set of tools in the testing toolbox are mocks. Mocks are used to isola
 ```
 
     ##    user  system elapsed 
-    ##   0.002   0.000   0.002
+    ##       0       0       0
 
 For more information:
 

--- a/content/r-package-dev/debugging.md
+++ b/content/r-package-dev/debugging.md
@@ -3,6 +3,7 @@ author: David Watkins
 date: 9999-04-30
 slug: debugging
 title: Debugging
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:


### PR DESCRIPTION
@ldecicco-USGS @jiwalker-usgs @aappling-usgs @wdwatkins can you check to see if you have the most  up-to-date version of the USGSmarkdowntemplates repo? 

I made a change here https://github.com/USGS-R/USGSmarkdowntemplates/pull/19, but your pages didn't automatically add `draft: True` like they should when you knit. 