### PR TITLE
change instructions for installing RTools

### DIFF
--- a/content/r-package-dev/Getting_Started.Rmd
+++ b/content/r-package-dev/Getting_Started.Rmd
@@ -43,7 +43,7 @@ Software installation:
 
 - [R](https://cran.rstudio.com/bin/windows/base/) (latest version)
 - [RStudio](https://www.rstudio.com/products/rstudio/download2/) (>1.0)
-- [RTools](https://cran.r-project.org/bin/windows/Rtools/) (most recent frozen version)
+- [RTools](https://cran.r-project.org/bin/windows/Rtools/) (compatible with your version of R)
 - R packages: devtools, roxygen2, testthat, knitr
 
 ## Suggested prerequisite knowledge

--- a/content/r-package-dev/Getting_Started.md
+++ b/content/r-package-dev/Getting_Started.md
@@ -26,7 +26,7 @@ Software installation:
 
 -   [R](https://cran.rstudio.com/bin/windows/base/) (latest version)
 -   [RStudio](https://www.rstudio.com/products/rstudio/download2/) (&gt;1.0)
--   [RTools](https://cran.r-project.org/bin/windows/Rtools/) (most recent frozen version)
+-   [RTools](https://cran.r-project.org/bin/windows/Rtools/) (compatible with your version of R)
 -   R packages: devtools, roxygen2, testthat, knitr
 
 Suggested prerequisite knowledge


### PR DESCRIPTION
Don't need to install the latest unfrozen version, just need to make sure it is compatible with your version of R. This came up because the only RTools compatible with 3.4.0 is unfrozen.

Self-merging, changes were discussed on Slack.