### PR TITLE
Getting menu order correct (not alphabetic)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 languageCode = "en-us"
-title = "Introduction to R"
+title = "R Curriculum"
 theme = "hugo_theme_robust"
 preserveTaxonomyNames = true
 paginate = 100
@@ -7,16 +7,16 @@ canonifyurls = true
 [[menu.main]]
   name = "Home: R Training Curriculum"
   url = "/"
-  weight = -1
-[[menu.main]]
-  name = "Introduction to R Course"
-  url = "/intro-curriculum/"
   weight = 1
 [[menu.main]]
   name = "Course Specific Material"
   url = "/course-specific-material/"
-  weight = 1
+  weight = 2
+[[menu.main]]
+  name = "Introduction to R Course"
+  url = "/intro-curriculum/"
+  weight = 3
 [[menu.main]]
   name = "Introduction to USGS R Packages"
   url = "/usgs-packages/"
-  weight = 1
+  weight = 4

--- a/content/r-package-dev/Defensive_Programming.Rmd
+++ b/content/r-package-dev/Defensive_Programming.Rmd
@@ -6,7 +6,7 @@ slug: "defense"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
-weight: 1
+weight: 30
 ---
 
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}

--- a/content/r-package-dev/Defensive_Programming.md
+++ b/content/r-package-dev/Defensive_Programming.md
@@ -8,7 +8,7 @@ image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
     parent: R Package Development
-    weight: 1
+    weight: 30
 ---
 Defensive programming means anticipating and avoiding problems before they occur. By giving informative messages as soon as you see a problem coming, you can simplify debugging, educate your users, and avoid long computations that you know will fail.
 

--- a/content/r-package-dev/Documentation.Rmd
+++ b/content/r-package-dev/Documentation.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Documentation"
-date: "9999-07-31"
+date: "9999-10-20"
 author: "Lindsay R. Carr"
 slug: "doc"
 image: "img/main/intro-icons-300px/r-logo.png"

--- a/content/r-package-dev/Documentation.Rmd
+++ b/content/r-package-dev/Documentation.Rmd
@@ -6,7 +6,7 @@ slug: "doc"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
-weight: 1
+weight: 20
 ---
 
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}

--- a/content/r-package-dev/Documentation.md
+++ b/content/r-package-dev/Documentation.md
@@ -8,7 +8,7 @@ image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
     parent: R Package Development
-    weight: 1
+    weight: 20
 ---
 The quality of documentation for an R package can determine success or failure. Less documentation generally results in higher burdens, so it's best add extensive documentation as early as possible. Consider different audiences when writing package documentation: the users, current or future developers, and future you. The better documented your package, the less like you are to be burdened by answering user questions, helping onboard future developers, and spending time remembering details about the code.
 

--- a/content/r-package-dev/Documentation.md
+++ b/content/r-package-dev/Documentation.md
@@ -1,6 +1,6 @@
 ---
 author: Lindsay R. Carr
-date: 9999-07-31
+date: 9999-10-20
 slug: doc
 title: Documentation
 draft: True
@@ -250,7 +250,7 @@ We will only show how to create HTML vignettes here. To start, create a top-leve
 
     title: "Vignette Title"
     author: "Vignette Author"
-    date: "2017-05-24"
+    date: "2017-05-30"
     output: rmarkdown::html_vignette
     vignette: >
       %\VignetteIndexEntry{Vignette Title}
@@ -264,7 +264,7 @@ In the body of the R Markdown document, add a code chunk that loads the `rmarkdo
     ---
     title: "Basic workflow of `myAwesomePackage`"
     author: "Vignette Author"
-    date: "2017-05-24"
+    date: "2017-05-30"
     output: rmarkdown::html_vignette
     vignette: >
       %\VignetteIndexEntry{Vignette Title}
@@ -301,7 +301,7 @@ The previous section discussed how to format R Markdown (`.Rmd` ) files and knit
 
     title: "README"
     author: "R"
-    date: "24 May, 2017"
+    date: "30 May, 2017"
     output:
       md_document:
         variant: markdown_github
@@ -311,7 +311,7 @@ Here is an example `README.Rmd`:
     ---
     title: "README"
     author: "R"
-    date: "24 May, 2017"
+    date: "30 May, 2017"
     output:
       md_document:
         variant: markdown_github

--- a/content/r-package-dev/Maintenance.Rmd
+++ b/content/r-package-dev/Maintenance.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Maintenance"
-date: "9999-09-30"
+date: "9999-06-30"
 author: "Jordan S. Read"
 slug: "maintenance"
 image: "img/main/intro-icons-300px/r-logo.png"

--- a/content/r-package-dev/Maintenance.Rmd
+++ b/content/r-package-dev/Maintenance.Rmd
@@ -6,7 +6,7 @@ slug: "maintenance"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
-weight: 1
+weight: 40
 ---
 
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}

--- a/content/r-package-dev/Maintenance.md
+++ b/content/r-package-dev/Maintenance.md
@@ -8,7 +8,7 @@ image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
     parent: R Package Development
-    weight: 1
+    weight: 40
 ---
 Package maintenance is the process of continuing to keep your package operating effectively over time, including keeping up with changes to R itself and the underlying packages that your package depends on. Additionally package maintainence often involves addressing minor bugs and optionally includes adding new features.
 

--- a/content/r-package-dev/Maintenance.md
+++ b/content/r-package-dev/Maintenance.md
@@ -1,6 +1,6 @@
 ---
 author: Jordan S. Read
-date: 9999-09-30
+date: 9999-06-30
 slug: maintenance
 title: Maintenance
 draft: True
@@ -83,7 +83,7 @@ The package version is meaningful regardless of whether you are supporting one o
 packageVersion('graphics')
 ```
 
-    ## [1] '3.4.0'
+    ## [1] '3.3.2'
 
 When you start a package, the major version should remain at 0 and stay that way until the package and features are mature enough to represent a set of functions and data that users of your package can program against as expect consistency. Changes to the major version represent changes that are expected to *break* the code of users that are relying on your package. Using a major version of 0 communicates to users that are familiar with these guidelines that the package features are unstable and subject to change without warning.
 

--- a/content/r-package-dev/Package_Mechanics.Rmd
+++ b/content/r-package-dev/Package_Mechanics.Rmd
@@ -5,7 +5,7 @@ slug: "mechanics"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
-weight: 1
+weight: 10
 ---
 
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}

--- a/content/r-package-dev/Package_Mechanics.md
+++ b/content/r-package-dev/Package_Mechanics.md
@@ -2,13 +2,13 @@
 author: 
 date: 9999-11-15
 slug: mechanics
-draft: true
 title: Package Mechanics
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
     parent: R Package Development
-    weight: 1
+    weight: 10
 ---
 This lesson provides definitions and examples of
 
@@ -132,7 +132,6 @@ More Sub-Directories
 
 Aside from the "R" and "man" folders, there are others that can be included in a package. Here is a brief introduction to those folders. Some will be discussed further in this course. Others can be explored further from online references.
 
-<!--html_preserve-->
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -240,13 +239,11 @@ Files to create the detailed vignette files/user guides
 </tr>
 </tbody>
 </table>
-<!--/html_preserve-->
 More Files
 ----------
 
 Aside from the "DESCRIPTION" and "NAMESPACE" files, there are others that can be included in a package. Here is a brief introduction to those files Some will be discussed further in this course. Others can be explored further from online references. This list is not exhaustive. There are many other files that can be seen on R-Package github repositories. Some that we may explore in this workshop for example, ".travis.yml", "appveyor.yml", "codecov.yml" are used to configure continuous integration services.
 
-<!--html_preserve-->
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -330,7 +327,6 @@ List of files to ignore when doing the package build
 </tr>
 </tbody>
 </table>
-<!--/html_preserve-->
 Data
 ----
 
@@ -348,7 +344,7 @@ path_to_data <- system.file("extdata", "RDB1Example.txt", package = "dataRetriev
 path_to_data
 ```
 
-    ## [1] "C:/Users/ldecicco/Documents/R/win-library/3.4/dataRetrieval/extdata/RDB1Example.txt"
+    ## [1] "C:/Users/lcarr/Documents/R/R-3.3.2/library/dataRetrieval/extdata/RDB1Example.txt"
 
 This data is not automatically exported in the package. For `dataRetrieval`, we could open the data file by using `dataRetrieval` parsing functions:
 

--- a/content/r-package-dev/Package_Thoughts.Rmd
+++ b/content/r-package-dev/Package_Thoughts.Rmd
@@ -5,7 +5,7 @@ slug: "packages"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
-weight: 1
+weight: 5
 ---
 
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}

--- a/content/r-package-dev/Package_Thoughts.md
+++ b/content/r-package-dev/Package_Thoughts.md
@@ -2,13 +2,13 @@
 author: 
 date: 9999-11-30
 slug: packages
-draft: true
 title: What Is a Package?
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
     parent: R Package Development
-    weight: 1
+    weight: 5
 ---
 By the end of the R-Package development course, the act of creating a package should be considered almost trivial. This lesson is intended to give developers topics to consider to decide if a group of work would make a thoughtful package.
 

--- a/content/r-package-dev/Version_Control.Rmd
+++ b/content/r-package-dev/Version_Control.Rmd
@@ -6,7 +6,7 @@ slug: "git"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
-weight: 1
+weight: 15
 ---
 
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}

--- a/content/r-package-dev/Version_Control.md
+++ b/content/r-package-dev/Version_Control.md
@@ -8,7 +8,7 @@ image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
     parent: R Package Development
-    weight: 1
+    weight: 15
 ---
 Version control is a tool that allows you to keep track of changes to a number of files. Using version control for package development means that you can easily revert to previous package versions, collaborate with multiple developers, and record reasons for the changes that are made. For this course, we will only discuss the version control language Git and its web interface, GitHub.
 

--- a/content/r-package-dev/Writing_Tests.Rmd
+++ b/content/r-package-dev/Writing_Tests.Rmd
@@ -6,7 +6,7 @@ slug: "writing-tests"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
-weight: 1
+weight: 35
 draft: true
 ---
 

--- a/content/r-package-dev/Writing_Tests.md
+++ b/content/r-package-dev/Writing_Tests.md
@@ -8,7 +8,7 @@ image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
     parent: R Package Development
-    weight: 1
+    weight: 35
 ---
 Formal software testing lays down a safety net to ensure that software performs the function it claims to. Not only will testing your packages improve the confidence level you have in your code, but it will make adding new functionality easier, improve the structure of your code, and save time that would otherwise be used to manually test. This lesson will go over general principles of testing and how to accomplish them in R using testthat.
 
@@ -129,7 +129,7 @@ One final set of tools in the testing toolbox are mocks. Mocks are used to isola
 ```
 
     ##    user  system elapsed 
-    ##   0.003   0.000   0.003
+    ##    0.02    0.00    0.02
 
 For more information:
 

--- a/content/r-package-dev/debugging.Rmd
+++ b/content/r-package-dev/debugging.Rmd
@@ -6,7 +6,7 @@ date: "9999-10-15"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
-weight: 1
+weight: 25
 draft: true
 ---
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}

--- a/content/r-package-dev/debugging.md
+++ b/content/r-package-dev/debugging.md
@@ -3,12 +3,12 @@ author: David Watkins
 date: 9999-10-15
 slug: debugging
 title: Debugging
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
     parent: R Package Development
-    weight: 1
-draft: true
+    weight: 25
 ---
 Debugging is an integral part of package development and maintenance. As you write more complex code, errors can often happen several functions deep. Unlike in a script, you don't by default have access to the R variables where the error occured. Fortunately, RStudio provides many useful tools to help.
 

--- a/themes/hugo_theme_robust/layouts/partials/sidebar.html
+++ b/themes/hugo_theme_robust/layouts/partials/sidebar.html
@@ -13,7 +13,7 @@
             <span class="accordionSignal"></span>
             <a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a>
             <ul>
-              {{ range .Children }}
+              {{ range .Children.ByWeight }}
               <li><a href="{{ .URL }}">{{ .Name }}</a></li>
               {{ end }}
             </ul>
@@ -21,7 +21,7 @@
           {{ else }}
           <li><a href="{{ .URL }}">{{ .Pre }} {{ .Name }}</a></li>
           {{ end }}
-          {{end}}
+          {{ end }}
         </ul>
         {{end}}
       </nav>

--- a/themes/hugo_theme_robust/layouts/section/r-package-dev.html
+++ b/themes/hugo_theme_robust/layouts/section/r-package-dev.html
@@ -8,7 +8,7 @@
       <h1 class="p-page-title">Introduction to R Package Development</h1>
 
       <div class="row">
-        {{ range $key, $value := first 10 (.Data.Pages.ByDate).Reverse }}
+        {{ range $key, $value := first 10 (.Data.Pages.ByWeight) }}
         
         <div class="col-sm-6">
           {{ .Render "grid" }}

--- a/themes/hugo_theme_robust/layouts/section/r-package-dev.html
+++ b/themes/hugo_theme_robust/layouts/section/r-package-dev.html
@@ -1,0 +1,31 @@
+{{ partial "header_before.html" . }}
+{{ partial "header_after.html" . }}
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-9">
+
+      <h1 class="p-page-title">Introduction to R Package Development</h1>
+
+      <div class="row">
+        {{ range $key, $value := first 10 (.Data.Pages.ByDate).Reverse }}
+        
+        <div class="col-sm-6">
+          {{ .Render "grid" }}
+        </div>
+        {{ end }}
+      </div>
+
+      {{ partial "pagination.html" . }}
+
+    </div>
+
+    <div class="col-md-3">
+      {{ partial "sidebar.html" . }}
+    </div>
+
+  </div>
+
+</div>
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
Figured out that "Children" don't have "Date" as a parameter, only weight. So now we can worry just about the weights, not the dates for r-pkg-dev.