### PR TITLE
fork dataRetrieval for debugging

### DIFF
--- a/content/r-package-dev/Version_Control.Rmd
+++ b/content/r-package-dev/Version_Control.Rmd
@@ -86,6 +86,7 @@ htmlTable(data.frame(Term, Definition),
 ```
 
 \html{<br>}
+<a name="our-workflow"></a>
 
 ## Our recommended workflow
 

--- a/content/r-package-dev/Version_Control.Rmd
+++ b/content/r-package-dev/Version_Control.Rmd
@@ -3,6 +3,7 @@ title: "Version Control"
 date: "9999-10-31"
 author: "Lindsay R. Carr"
 slug: "git"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development

--- a/content/r-package-dev/Version_Control.md
+++ b/content/r-package-dev/Version_Control.md
@@ -3,7 +3,7 @@ author: Lindsay R. Carr
 date: 9999-10-31
 slug: git
 title: Version Control
-draft: True
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/Version_Control.md
+++ b/content/r-package-dev/Version_Control.md
@@ -3,6 +3,7 @@ author: Lindsay R. Carr
 date: 9999-10-31
 slug: git
 title: Version Control
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
@@ -134,6 +135,7 @@ refers to the main branch in a repository
 </tbody>
 </table>
 <!--/html_preserve-->
+ <a name="our-workflow"></a>
 
 Our recommended workflow
 ------------------------

--- a/content/r-package-dev/debugging.Rmd
+++ b/content/r-package-dev/debugging.Rmd
@@ -108,6 +108,9 @@ Use `debugonce` or `debug` and the associated commands to follow the function ca
 
 ## Debugging an unfamiliar function
 For a more complex example let's use a function from the `dataRetrieval` package, by supplying an invalid site number that will cause an error.  
+
+First, fork a copy of the `dataRetrieval` package at [https://github.com/USGS-R/dataRetrieval](https://github.com/USGS-R/dataRetrieval).  Remember that you have already done this before in the version control lesson [here](../git/#our-workflow).  Once you have your local copy of the package, build and reload it using either the `Build and Reload` button in the `Build` tab of the environment pane, or pressing Cntl-Shift-B.  Having a package built from source gives you more options for debugging, such as breakpoints, and automatic traceback of errors.  The `debug` and `traceback` functions always work though.  
+
 ```{r eval=FALSE}
 #install.packages('dataRetrieval') #if you don't already have it installed
 library(dataRetrieval)

--- a/content/r-package-dev/debugging.Rmd
+++ b/content/r-package-dev/debugging.Rmd
@@ -3,11 +3,11 @@ title: "Debugging"
 author: "David Watkins"
 slug: "debugging"
 date: "9999-10-15"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
 weight: 25
-draft: true
 ---
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}
 library(knitr)

--- a/content/r-package-dev/debugging.md
+++ b/content/r-package-dev/debugging.md
@@ -3,7 +3,7 @@ author: David Watkins
 date: 9999-10-15
 slug: debugging
 title: Debugging
-draft: True
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/debugging.md
+++ b/content/r-package-dev/debugging.md
@@ -3,6 +3,7 @@ author: David Watkins
 date: 9999-10-15
 slug: debugging
 title: Debugging
+draft: True
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
@@ -108,6 +109,8 @@ Debugging an unfamiliar function
 --------------------------------
 
 For a more complex example let's use a function from the `dataRetrieval` package, by supplying an invalid site number that will cause an error.
+
+First, fork a copy of the `dataRetrieval` package at <https://github.com/USGS-R/dataRetrieval>. Remember that you have already done this before in the version control lesson [here](../git/#our-workflow). Once you have your local copy of the package, build and reload it using either the `Build and Reload` button in the `Build` tab of the environment pane, or pressing Cntl-Shift-B. Having a package built from source gives you more options for debugging, such as breakpoints, and automatic traceback of errors. The `debug` and `traceback` functions always work though.
 
 ``` r
 #install.packages('dataRetrieval') #if you don't already have it installed


### PR DESCRIPTION
@limnoliver pointed out some of these debugging features don't work if you don't have the package built from source.  It probably makes sense longer term to just use an example from our example repo, so some git/github can be incorporated.

Need to remove draft tags, don't merge yet