### PR TITLE
version control ended up w/ draft: true + update all pkg dev lessons w/ draft: "FALSE"

### DIFF
--- a/content/r-package-dev/Defensive_Programming.Rmd
+++ b/content/r-package-dev/Defensive_Programming.Rmd
@@ -3,6 +3,7 @@ title: "Defensive Programming"
 date: "9999-09-30"
 author: "Alison P. Appling"
 slug: "defense"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development

--- a/content/r-package-dev/Defensive_Programming.md
+++ b/content/r-package-dev/Defensive_Programming.md
@@ -3,6 +3,7 @@ author: Alison P. Appling
 date: 9999-09-30
 slug: defense
 title: Defensive Programming
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/Documentation.Rmd
+++ b/content/r-package-dev/Documentation.Rmd
@@ -3,6 +3,7 @@ title: "Documentation"
 date: "9999-10-20"
 author: "Lindsay R. Carr"
 slug: "doc"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development

--- a/content/r-package-dev/Documentation.md
+++ b/content/r-package-dev/Documentation.md
@@ -3,6 +3,7 @@ author: Lindsay R. Carr
 date: 9999-10-20
 slug: doc
 title: Documentation
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
@@ -249,7 +250,7 @@ We will only show how to create HTML vignettes here. To start, create a top-leve
 
     title: "Vignette Title"
     author: "Vignette Author"
-    date: "2017-05-31"
+    date: "2017-06-09"
     output: rmarkdown::html_vignette
     vignette: >
       %\VignetteIndexEntry{Vignette Title}
@@ -263,7 +264,7 @@ In the body of the R Markdown document, add a code chunk that loads the `rmarkdo
     ---
     title: "Basic workflow of `myAwesomePackage`"
     author: "Vignette Author"
-    date: "2017-05-31"
+    date: "2017-06-09"
     output: rmarkdown::html_vignette
     vignette: >
       %\VignetteIndexEntry{Vignette Title}
@@ -300,7 +301,7 @@ The previous section discussed how to format R Markdown (`.Rmd` ) files and knit
 
     title: "README"
     author: "R"
-    date: "31 May, 2017"
+    date: "09 June, 2017"
     output:
       md_document:
         variant: markdown_github
@@ -310,7 +311,7 @@ Here is an example `README.Rmd`:
     ---
     title: "README"
     author: "R"
-    date: "31 May, 2017"
+    date: "09 June, 2017"
     output:
       md_document:
         variant: markdown_github

--- a/content/r-package-dev/Getting_Started.Rmd
+++ b/content/r-package-dev/Getting_Started.Rmd
@@ -3,6 +3,7 @@ title: "Getting Started"
 date: "9999-12-31"
 author: "Lindsay R. Carr"
 slug: "getting-started"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development

--- a/content/r-package-dev/Getting_Started.md
+++ b/content/r-package-dev/Getting_Started.md
@@ -3,6 +3,7 @@ author: Lindsay R. Carr
 date: 9999-12-31
 slug: getting-started
 title: Getting Started
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/Maintenance.Rmd
+++ b/content/r-package-dev/Maintenance.Rmd
@@ -3,6 +3,7 @@ title: "Maintenance"
 date: "9999-06-30"
 author: "Jordan S. Read"
 slug: "maintenance"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development

--- a/content/r-package-dev/Maintenance.md
+++ b/content/r-package-dev/Maintenance.md
@@ -86,7 +86,7 @@ The package version is meaningful regardless of whether you are supporting one o
 packageVersion('graphics')
 ```
 
-    ## [1] '3.4.0'
+    ## [1] '3.3.2'
 
 When you start a package, the major version should remain at 0 and stay that way until the package and features are mature enough to represent a set of functions and data that users of your package can program against as expect consistency. Changes to the major version represent changes that are expected to *break* the code of users that are relying on your package. Using a major version of 0 communicates to users that are familiar with these guidelines that the package features are unstable and subject to change without warning.
 

--- a/content/r-package-dev/Package_Mechanics.Rmd
+++ b/content/r-package-dev/Package_Mechanics.Rmd
@@ -3,6 +3,7 @@ title: "Package Mechanics"
 date: "9999-11-15"
 author: Laura DeCicco
 slug: "mechanics"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development

--- a/content/r-package-dev/Package_Mechanics.md
+++ b/content/r-package-dev/Package_Mechanics.md
@@ -3,6 +3,7 @@ author: Laura DeCicco
 date: 9999-11-15
 slug: mechanics
 title: Package Mechanics
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/Package_Thoughts.Rmd
+++ b/content/r-package-dev/Package_Thoughts.Rmd
@@ -3,6 +3,7 @@ title: "What Is a Package?"
 date: "9999-11-30"
 author: Laura DeCicco
 slug: "packages"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development

--- a/content/r-package-dev/Package_Thoughts.md
+++ b/content/r-package-dev/Package_Thoughts.md
@@ -3,6 +3,7 @@ author: Laura DeCicco
 date: 9999-11-30
 slug: packages
 title: What Is a Package?
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/Version_Control.md
+++ b/content/r-package-dev/Version_Control.md
@@ -3,7 +3,7 @@ author: Lindsay R. Carr
 date: 9999-10-31
 slug: git
 title: Version Control
-draft: True
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:

--- a/content/r-package-dev/Writing_Tests.Rmd
+++ b/content/r-package-dev/Writing_Tests.Rmd
@@ -3,11 +3,11 @@ title: "Writing Tests"
 date: "9999-08-31"
 author: "Jordan I. Walker"
 slug: "writing-tests"
+draft: "FALSE"
 image: "img/main/intro-icons-300px/r-logo.png"
 output: USGSmarkdowntemplates::hugoTraining
 parent: R Package Development
 weight: 35
-draft: true
 ---
 
 ```{r setup, include=FALSE, warning=FALSE, message=FALSE}

--- a/content/r-package-dev/Writing_Tests.md
+++ b/content/r-package-dev/Writing_Tests.md
@@ -3,6 +3,7 @@ author: Jordan I. Walker
 date: 9999-08-31
 slug: writing-tests
 title: Writing Tests
+draft: FALSE 
 image: img/main/intro-icons-300px/r-logo.png
 menu:
   main:
@@ -129,7 +130,7 @@ One final set of tools in the testing toolbox are mocks. Mocks are used to isola
 ```
 
     ##    user  system elapsed 
-    ##       0       0       0
+    ##    0.02    0.00    0.02
 
 For more information:
 


### PR DESCRIPTION
Using the GRAN release v0.0.10 of "USGSmarkdowntemplates", the `draft: "FALSE"` tag can be added to approved pages so that knitting them does not automatically change them to a draft. 