### PR TITLE
don't need intall intructions in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,10 +9,6 @@ canonifyurls = true
   url = "/"
   weight = 1
 [[menu.main]]
-  name = "R Installation Instructions"
-  url = "/installr/"
-  weight = 2
-[[menu.main]]
   name = "Introduction to R Course"
   url = "/intro-curriculum/"
   weight = 3


### PR DESCRIPTION
It worked just fine when I built locally, but was causing builds to fail on Jenkins.

Local:
```
export HUGO_BASEURL="training-curriculum/"
hugo server --theme=hugo_theme_robust --buildDrafts
```

Jenkins error:
```
ERROR: 2017/07/13 08:41:46 site.go:1211: Two or more menu items have the same name/identifier in Menu "main": "R Installation Instructions".
Rename or set an unique identifier.
```

Tried removing the menu entry in `config.toml` and it still shows up in the menu, so I'm assuming this will fix it. We won't know until this is merged and I try building on Jenkins. So, going to self merge and try that.