### PR TITLE
stop odd code coloring

### DIFF
--- a/themes/hugo_theme_robust/static/css/styles.css
+++ b/themes/hugo_theme_robust/static/css/styles.css
@@ -49,7 +49,7 @@ caption {
 }
 
 .hljs-built_in{
-  color:#ed6a43;
+  color:#000;
 }
  
  


### PR DESCRIPTION
This CSS line was the culprit of making certain things highlighted. If this somehow changes we want to be highlighted this may need a more in depth fix. 