### PR TITLE
removing some importants

### DIFF
--- a/themes/hugo_theme_robust/static/css/styles.css
+++ b/themes/hugo_theme_robust/static/css/styles.css
@@ -47,7 +47,7 @@ caption {
 .hljs-preprocessor > .hljs-title,
 .hljs-preprocessor,
 .hljs-comment{
-  color:#586e75 !important;
+  color:#586e75;
 }
 
 .hljs-value,
@@ -62,7 +62,7 @@ caption {
 .hljs-attribute,
 .hljs-attr_selector,
 .hljs-built_in{
-  color:#000  !important;
+  color:#000;
 }
  
  


### PR DESCRIPTION
@lindsaycarr We had 2 .hljs-title declarations for its color with !important on it, which is going to make the CSS fight and the last declared declaration wins out, I removed both !important's and the .hljs-title's within the .hljs-preprocessor became the color we want them to be, without the !important. 