### PR TITLE
data page was stuck as draft

### DIFF
--- a/content/intro-curriculum/data.Rmd
+++ b/content/intro-curriculum/data.Rmd
@@ -5,6 +5,7 @@ slug: "data"
 output: USGSmarkdowntemplates::hugoTraining
 parent: Introduction to R Course
 weight: 2
+draft: "FALSE"
 ---
 
 [IonBalance.csv](../data/IonBalance.csv)

--- a/content/intro-curriculum/data.md
+++ b/content/intro-curriculum/data.md
@@ -3,6 +3,7 @@ author:
 date: 9998-01-01
 slug: data
 title: Data
+draft: FALSE 
 image: 
 menu:
   main:

--- a/content/intro-curriculum/data.md
+++ b/content/intro-curriculum/data.md
@@ -3,7 +3,6 @@ author:
 date: 9998-01-01
 slug: data
 title: Data
-draft: TRUE 
 image: 
 menu:
   main:


### PR DESCRIPTION
This wasn't making it to prod due to the draft tag, so the old version wasn't being overwritten.   I added the draft="FALSE" tag so we don't have to hand edit the markdown each time.  Added to `USGSmarkdowntemplates` here: https://github.com/USGS-R/USGSmarkdowntemplates/commit/b3ea3759b0aac7bde5fe1cfec811589f6fcd53cb